### PR TITLE
Add webpack-dev-server to serve front end code 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack -d -watch"
+    "build": "webpack -d -watch",
+    "start": "webpack serve --open"
   },
   "repository": {
     "type": "git",
@@ -37,6 +38,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "jest": "^26.6.3",
     "webpack": "^4.46.0",
-    "webpack-cli": "^4.6.0"
+    "webpack-cli": "^4.6.0",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,19 @@
 const path = require('path');
 
-module.exports = { entry: './src/index.jsx', output: { filename: 'bundle.js', path: path.resolve(__dirname, 'public') }, module: { rules: [{ test: /.jsx?$/, exclude: /node_modules/, loader: 'babel-loader' }] } };
+module.exports = {
+  entry: './src/index.jsx',
+  mode: 'development',
+  devtool: 'inline-source-map',
+  devServer: {
+    contentBase: './public',
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'public'),
+  },
+  module: {
+    rules: [
+      { test: /.jsx?$/, exclude: /node_modules/, loader: 'babel-loader' },
+    ],
+  },
+};


### PR DESCRIPTION
- Allows the react-dev tools to function as expected 
- Will require you to run npm install when you pull down the update (install webpack-dev-server)
- Added a "start" script to the package json